### PR TITLE
Moodle_Popups.js 

### DIFF
--- a/Moodle_Popups.js
+++ b/Moodle_Popups.js
@@ -1,53 +1,149 @@
 // ==UserScript==
-// @name         BLUE_MOODLE.ClosePopup() Hijacker
+// @name         BLUE_MOODLE Kill All Popups Toggle (with Block Counter)
 // @namespace    https://moodle.uowplatform.edu.au/
-// @version      1.3
-// @description  Hijacks ClosePopup to fully remove popups and overlays from UOW Moodle without reloading the page.
-// @author       Gabriel
+// @version      2.8
+// @description  Toggle to block Moodle popups with a persistent setting and live counter of blocked popups displayed on the button
+// @author       Luke
 // @match        https://moodle.uowplatform.edu.au/*
 // @grant        none
+// @run-at       document-idle
 // ==/UserScript==
 
 (() => {
     'use strict';
 
-    // Number of retries to wait for BLUE_MOODLE to load
-    let retries = 100;
+    const TOGGLE_KEY = 'popupVisibilityAllowed';
+    let popupBlockingEnabled = localStorage.getItem(TOGGLE_KEY) === 'false';
+    let popupBlockedCount = 0;
 
-    // Set up a repeating interval check every 100ms
-    const interval = setInterval(() => {
-        // Reference to the global BLUE_MOODLE object
-        const bm = window.BLUE_MOODLE;
+    const createHeaderToggleButton = () => {
+        const toggleItem = document.createElement('li');
+        toggleItem.className = 'rui-icon-menu-togglepopups';
 
-        // Exit if retries run out OR the required functions exist
-        if (!--retries || (bm?.ClosePopup && bm?.CommonPopUp)) {
-            // Stop further interval checks
-            clearInterval(interval);
+        const btn = document.createElement('button');
+        btn.id = "popup-toggle-btn";
+        btn.type = "button";
+        btn.title = "Click to toggle popup visibility";
+        btn.style.position = "relative";
+        btn.style.padding = "6px 12px";
+        btn.style.fontSize = "13px";
+        btn.style.border = "1px solid #ccc";
+        btn.style.borderRadius = "6px";
+        btn.style.margin = "4px";
+        btn.style.cursor = "pointer";
+        btn.style.color = "white";
 
-            // If the ClosePopup function exists on BLUE_MOODLE
-            if (bm?.ClosePopup) {
-                // Override the ClosePopup function
-                bm.ClosePopup = (id = "dvOuter") => {
-                    // Attempt to get the element by ID (default "dvOuter")
-                    const el = document.getElementById(id);
+        const badge = document.createElement('span');
+        badge.id = "popup-blocked-count";
+        badge.textContent = "0";
+        badge.style.position = "absolute";
+        badge.style.top = "-4px";
+        badge.style.right = "-6px";
+        badge.style.background = "#f44336";
+        badge.style.color = "white";
+        badge.style.fontSize = "10px";
+        badge.style.padding = "2px 5px";
+        badge.style.borderRadius = "50%";
+        badge.style.display = "none";
+        badge.style.minWidth = "18px";
+        badge.style.textAlign = "center";
 
-                    // If element not found, log a warning and exit
-                    if (!el) return console.warn(`[TM] Element '${id}' not found.`);
+        const updateButton = () => {
+            btn.textContent = `Popups: ${popupBlockingEnabled ? "OFF" : "ON"}`;
+            btn.style.background = popupBlockingEnabled ? "#e53935" : "#43a047";
 
-                    // Get the parent of the element
-                    const parent = el.parentNode;
+            // Reattach the badge (textContent overwrite removes it)
+            btn.appendChild(badge);
+        };
 
-                    // If the parent is the overlay container (dvOuter), remove the entire container
-                    if (parent?.id === "dvOuter") {
-                        parent.remove();
-                        console.log(`[TM] Removed popup container and overlay.`);
-                    } else {
-                        // Otherwise, remove just the specific element
-                        el.remove();
-                        console.log(`[TM] Removed popup element with id: ${id}`);
-                    }
-                };
-            }
+        btn.addEventListener("click", () => {
+            popupBlockingEnabled = !popupBlockingEnabled;
+            localStorage.setItem(TOGGLE_KEY, !popupBlockingEnabled); 
+            updateButton();
+            console.log(`[TM] Popups are now ${popupBlockingEnabled ? "BLOCKED (OFF)" : "ALLOWED (ON)"}`);
+        });
+
+        updateButton();
+        toggleItem.appendChild(btn);
+
+        const ul = document.querySelector('ul.rui-icon-menu.rui-icon-menu--right.ml-auto');
+        if (ul) {
+            ul.insertBefore(toggleItem, ul.firstChild);
+        } else {
+            console.warn("[TM] Header menu not found — can't insert popup toggle.");
         }
-    }, 100); // Retry interval: 100ms
+
+        return badge;
+    };
+
+    const observePopups = (badge) => {
+        const observer = new MutationObserver(mutations => {
+            if (!popupBlockingEnabled) return;
+
+            mutations.forEach(mutation => {
+                mutation.addedNodes.forEach(node => {
+                    if (node.nodeType !== 1) return;
+
+                    const el = node.closest?.("#dvOuter") || node.querySelector?.("#dvOuter");
+                    if (el) {
+                        el.remove();
+                        popupBlockedCount++;
+                        badge.textContent = popupBlockedCount;
+                        badge.style.display = "inline-block";
+                        console.log(`[TM] Popup #${popupBlockedCount} blocked`);
+                    }
+                });
+            });
+        });
+
+        observer.observe(document.body, { childList: true, subtree: true });
+    };
+
+    const overrideClosePopup = (bm, badge) => {
+        const original = bm.ClosePopup;
+        bm.ClosePopup = (id = "dvOuter") => {
+            const el = document.getElementById(id);
+            if (!el) return console.warn(`[TM] Element '${id}' not found.`);
+            if (popupBlockingEnabled) {
+                const parent = el.parentNode;
+                if (parent?.id === "dvOuter") {
+                    parent.remove();
+                } else {
+                    el.remove();
+                }
+                popupBlockedCount++;
+                badge.textContent = popupBlockedCount;
+                badge.style.display = "inline-block";
+                console.log(`[TM] Intercepted popup #${popupBlockedCount} with id: ${id}`);
+            } else {
+                original?.call(bm, id);
+                console.log(`[TM] Allowed popup (blocking off) for: ${id}`);
+            }
+        };
+    };
+
+	// Added to make sure that the script will run on Firefox
+    const waitForBM = (badge) => {
+        let attempts = 0;
+        const maxAttempts = 100;
+        const interval = setInterval(() => {
+            const bm = window.BLUE_MOODLE;
+            if (bm?.ClosePopup && bm?.CommonPopUp) {
+                clearInterval(interval);
+                overrideClosePopup(bm, badge);
+                console.log("[TM] BLUE_MOODLE.ClosePopup overridden.");
+            }
+            if (++attempts > maxAttempts) {
+                clearInterval(interval);
+                console.warn("[TM] BLUE_MOODLE never loaded.");
+            }
+        }, 200);
+    };
+	
+	//On load event listener
+    window.addEventListener('load', () => {
+        const badge = createHeaderToggleButton();
+        observePopups(badge);
+        waitForBM(badge);
+    });
 })();

--- a/Moodle_Popups.js
+++ b/Moodle_Popups.js
@@ -1,9 +1,9 @@
 // ==UserScript==
-// @name         BLUE_MOODLE Kill All Popups Toggle (with Block Counter)
+// @name         BLUE_MOODLE.Popup Hijacker + Toggle
 // @namespace    https://moodle.uowplatform.edu.au/
-// @version      2.8
-// @description  Toggle to block Moodle popups with a persistent setting and live counter of blocked popups displayed on the button
-// @author       Luke
+// @version      4.0
+// @description  Toggle and block Moodle popups with toast notifications, badge counter, mutation observer, and localStorage state.
+// @author       Gabriel & Luke
 // @match        https://moodle.uowplatform.edu.au/*
 // @grant        none
 // @run-at       document-idle
@@ -12,138 +12,162 @@
 (() => {
     'use strict';
 
-    const TOGGLE_KEY = 'popupVisibilityAllowed';
-    let popupBlockingEnabled = localStorage.getItem(TOGGLE_KEY) === 'false';
-    let popupBlockedCount = 0;
+    const TOGGLE_KEY = 'popupVisibilityAllowed'; // Key for storing popup visibility toggle state in localStorage
+    let blocking = localStorage.getItem(TOGGLE_KEY) === 'false'; // Determine initial blocking state
+    let count = 0; // Counter for how many popups were blocked
 
-    const createHeaderToggleButton = () => {
-        const toggleItem = document.createElement('li');
-        toggleItem.className = 'rui-icon-menu-togglepopups';
+    // Helper function to apply inline styles to an element
+    const style = (el, styles) => Object.assign(el.style, styles);
 
-        const btn = document.createElement('button');
+    // Display a toast notification in the bottom-right corner
+    const showToast = (msg) => {
+        let toast = document.getElementById("popup-toast") || (() => {
+            const el = document.createElement("div");
+            el.id = "popup-toast";
+
+            // Styling for the toast
+            style(el, {
+                position: "fixed", bottom: "20px", right: "20px", background: "#323232", color: "#fff",
+                padding: "10px 15px", borderRadius: "6px", boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+                fontSize: "13px", zIndex: 9999, opacity: 0, transition: "opacity 0.3s ease",
+                maxWidth: "300px", wordWrap: "break-word", display: "flex",
+                alignItems: "center", justifyContent: "space-between", gap: "10px",
+            });
+
+            const text = document.createElement("span");
+            const close = document.createElement("span");
+            close.textContent = "❌";
+            close.title = "Dismiss";
+            close.style.cursor = "pointer";
+            close.style.fontSize = "12px";
+            close.onclick = () => (el.style.opacity = "0", clearTimeout(el._timeout));
+            el.append(text, close);
+            el._text = text;
+            document.body.appendChild(el);
+            return el;
+        })();
+
+        toast._text.textContent = msg;
+        toast.style.opacity = "1";
+        clearTimeout(toast._timeout);
+        toast._timeout = setTimeout(() => (toast.style.opacity = "0"), 4000);
+    };
+
+    // Create toggle button with badge that appears in Moodle's top-right menu
+    const createToggle = () => {
+        const btn = document.createElement("button");
         btn.id = "popup-toggle-btn";
         btn.type = "button";
-        btn.title = "Click to toggle popup visibility";
-        btn.style.position = "relative";
-        btn.style.padding = "6px 12px";
-        btn.style.fontSize = "13px";
-        btn.style.border = "1px solid #ccc";
-        btn.style.borderRadius = "6px";
-        btn.style.margin = "4px";
-        btn.style.cursor = "pointer";
-        btn.style.color = "white";
+        btn.title = "Toggle popup visibility";
 
-        const badge = document.createElement('span');
+        const badge = document.createElement("span");
         badge.id = "popup-blocked-count";
-        badge.textContent = "0";
-        badge.style.position = "absolute";
-        badge.style.top = "-4px";
-        badge.style.right = "-6px";
-        badge.style.background = "#f44336";
-        badge.style.color = "white";
-        badge.style.fontSize = "10px";
-        badge.style.padding = "2px 5px";
-        badge.style.borderRadius = "50%";
-        badge.style.display = "none";
-        badge.style.minWidth = "18px";
-        badge.style.textAlign = "center";
 
-        const updateButton = () => {
-            btn.textContent = `Popups: ${popupBlockingEnabled ? "OFF" : "ON"}`;
-            btn.style.background = popupBlockingEnabled ? "#e53935" : "#43a047";
+        // Button styles
+        style(btn, {
+            position: "relative", padding: "6px 12px", fontSize: "13px",
+            border: "1px solid #ccc", borderRadius: "6px", margin: "4px",
+            cursor: "pointer", color: "#fff"
+        });
 
-            // Reattach the badge (textContent overwrite removes it)
+        // Badge styles
+        style(badge, {
+            position: "absolute", top: "-4px", right: "-6px", background: "#f44336",
+            color: "#fff", fontSize: "10px", padding: "2px 5px", borderRadius: "50%",
+            display: "none", minWidth: "18px", textAlign: "center"
+        });
+
+        // Update toggle button appearance and text
+        const update = () => {
+            btn.textContent = `Popups: ${blocking ? "OFF" : "ON"}`;
+            btn.style.background = blocking ? "#e53935" : "#43a047";
             btn.appendChild(badge);
         };
 
-        btn.addEventListener("click", () => {
-            popupBlockingEnabled = !popupBlockingEnabled;
-            localStorage.setItem(TOGGLE_KEY, !popupBlockingEnabled); 
-            updateButton();
-            console.log(`[TM] Popups are now ${popupBlockingEnabled ? "BLOCKED (OFF)" : "ALLOWED (ON)"}`);
-        });
+        // Toggle button click behavior
+        btn.onclick = () => {
+            blocking = !blocking;
+            localStorage.setItem(TOGGLE_KEY, !blocking);
+            count = 0;
+            badge.textContent = "0";
+            badge.style.display = "none";
+            update();
+            console.log(`[TM] Popups are now ${blocking ? "BLOCKED (OFF)" : "ALLOWED (ON)"}`);
+        };
 
-        updateButton();
-        toggleItem.appendChild(btn);
+        update();
 
-        const ul = document.querySelector('ul.rui-icon-menu.rui-icon-menu--right.ml-auto');
-        if (ul) {
-            ul.insertBefore(toggleItem, ul.firstChild);
-        } else {
-            console.warn("[TM] Header menu not found — can't insert popup toggle.");
-        }
+        // Inject toggle button into Moodle's existing menu
+        const li = document.createElement("li");
+        li.className = "rui-icon-menu-togglepopups";
+        li.appendChild(btn);
 
+        const ul = document.querySelector("ul.rui-icon-menu.rui-icon-menu--right.ml-auto");
+        ul?.insertBefore(li, ul.firstChild) || console.warn("[TM] Header menu not found.");
         return badge;
     };
 
-    const observePopups = (badge) => {
-        const observer = new MutationObserver(mutations => {
-            if (!popupBlockingEnabled) return;
-
-            mutations.forEach(mutation => {
-                mutation.addedNodes.forEach(node => {
-                    if (node.nodeType !== 1) return;
-
-                    const el = node.closest?.("#dvOuter") || node.querySelector?.("#dvOuter");
-                    if (el) {
-                        el.remove();
-                        popupBlockedCount++;
-                        badge.textContent = popupBlockedCount;
-                        badge.style.display = "inline-block";
-                        console.log(`[TM] Popup #${popupBlockedCount} blocked`);
-                    }
-                });
-            });
-        });
-
-        observer.observe(document.body, { childList: true, subtree: true });
+    // Logic for blocking and removing popup elements
+    const blockPopup = (el, badge, method) => {
+        const heading = el.querySelector("#bluePopupHeading")?.innerText?.trim() || "Unnamed Popup";
+        el.remove();
+        count++;
+        badge.textContent = count;
+        badge.style.display = "inline-block";
+        console.log(`[TM] Popup #${count} blocked (${method})`);
+        showToast(`Popup blocked: "${heading}"`);
     };
 
-    const overrideClosePopup = (bm, badge) => {
+    // Use a MutationObserver to detect when popups are added to the DOM
+    const observe = (badge) => {
+        new MutationObserver(muts => {
+            if (!blocking) return;
+            muts.forEach(m => [...m.addedNodes].forEach(node => {
+                if (!(node instanceof HTMLElement)) return;
+                const el = node.id === "dvBlueTasksPrompt"
+                    ? node
+                    : node.closest?.("#dvBlueTasksPrompt") || node.querySelector?.("#dvBlueTasksPrompt");
+                if (el) blockPopup(el, badge, "mutation");
+            }));
+        }).observe(document.body, { childList: true, subtree: true });
+    };
+
+    // Override the native BLUE_MOODLE.ClosePopup function to intercept popups
+    const override = (bm, badge) => {
         const original = bm.ClosePopup;
         bm.ClosePopup = (id = "dvOuter") => {
             const el = document.getElementById(id);
             if (!el) return console.warn(`[TM] Element '${id}' not found.`);
-            if (popupBlockingEnabled) {
-                const parent = el.parentNode;
-                if (parent?.id === "dvOuter") {
-                    parent.remove();
-                } else {
-                    el.remove();
-                }
-                popupBlockedCount++;
-                badge.textContent = popupBlockedCount;
-                badge.style.display = "inline-block";
-                console.log(`[TM] Intercepted popup #${popupBlockedCount} with id: ${id}`);
+
+            if (blocking) {
+                const target = el.id === "dvBlueTasksPrompt" ? el : el.closest?.("#dvBlueTasksPrompt");
+                blockPopup(target || el, badge, "ClosePopup");
             } else {
                 original?.call(bm, id);
-                console.log(`[TM] Allowed popup (blocking off) for: ${id}`);
+                console.log(`[TM] Popup allowed (id: ${id})`);
+                const outer = document.getElementById("dvOuter");
+                if (outer?.children.length === 0) outer.remove(); // Clean up if no children left
             }
         };
+        console.log("[TM] ClosePopup override applied.");
     };
 
-	// Added to make sure that the script will run on Firefox
+    // Wait for BLUE_MOODLE object to become available, then override
     const waitForBM = (badge) => {
-        let attempts = 0;
-        const maxAttempts = 100;
+        let tries = 100;
         const interval = setInterval(() => {
             const bm = window.BLUE_MOODLE;
-            if (bm?.ClosePopup && bm?.CommonPopUp) {
+            if (!--tries || (bm?.ClosePopup && bm?.CommonPopUp)) {
                 clearInterval(interval);
-                overrideClosePopup(bm, badge);
-                console.log("[TM] BLUE_MOODLE.ClosePopup overridden.");
+                bm?.ClosePopup ? override(bm, badge) : console.warn("[TM] BLUE_MOODLE.ClosePopup not found.");
             }
-            if (++attempts > maxAttempts) {
-                clearInterval(interval);
-                console.warn("[TM] BLUE_MOODLE never loaded.");
-            }
-        }, 200);
+        }, 100);
     };
-	
-	//On load event listener
+
+    // Run once the page fully loads
     window.addEventListener('load', () => {
-        const badge = createHeaderToggleButton();
-        observePopups(badge);
-        waitForBM(badge);
+        const badge = createToggle(); // Create UI toggle button
+        observe(badge); // Start watching for popups
+        waitForBM(badge); // Wait and hook into BLUE_MOODLE functions
     });
 })();

--- a/Moodle_Popups.js
+++ b/Moodle_Popups.js
@@ -47,6 +47,7 @@
             return el;
         })();
 
+		// This Toast is a baller idea! solid work Gabriel.
         toast._text.textContent = msg;
         toast.style.opacity = "1";
         clearTimeout(toast._timeout);


### PR DESCRIPTION
**Changes in version 1.4:**

Toggle Button UI Improvements
 Reworded the toggle label to be more intuitive:
 • Popups: ON means popups are allowed
 • Popups: OFF means popups are blocked

Persistent Popup Toggle Setting
 • The script now uses localStorage (popupVisibilityAllowed) to remember the toggle state across page loads.
 • Default behaviour is to allow popups unless previously disabled by the user.

Live Popup Block Counter
 • A red badge on the toggle button shows how many popups have been blocked during the current session.
 • The counter updates in real time and works with both DOM-inserted #dvOuter elements and intercepted BLUE_MOODLE.ClosePopup() calls.

Header Integration
 • The toggle button is now injected directly into Moodle’s header bar (rui-icon-menu--right) for a cleaner and more native interface placement.

Firefox Compatibility
 • A retry mechanism (waitForBM) has been added to ensure the script waits for BLUE_MOODLE to load fully, improving reliability on Firefox and slower connections.

Console Logging Improvements
 • Console output has been made clearer, logging the number of blocked popups and the current toggle state for easier debugging and monitoring.