### PR TITLE
Create Moodle_Overdue_Remover.js

### DIFF
--- a/Moodle_Overdue_Remover.js
+++ b/Moodle_Overdue_Remover.js
@@ -1,0 +1,37 @@
+// ==UserScript==
+// @name         Moodle Overdue Notifications Blocker
+// @namespace    http://tampermonkey.net/
+// @version      0.1
+// @description  Hides "overdue" badges in Moodle
+// @author       You
+// @match        https://moodle.uowplatform.edu.au/*
+// @grant        none
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    // Function to hide overdue notifications
+    function hideOverdueBadges() {
+        // Get all overdue badges
+        const overdueBadges = document.querySelectorAll('.badge-danger');
+        
+        // Hide each overdue badge
+        overdueBadges.forEach(badge => {
+            if (badge.textContent.toLowerCase().includes('overdue')) {
+                badge.style.display = 'none';
+            }
+        });
+    }
+
+    // Initial call to hide existing badges
+    hideOverdueBadges();
+    
+    // Set up a MutationObserver to handle dynamically loaded content
+    const observer = new MutationObserver(function(mutations) {
+        hideOverdueBadges();
+    });
+    
+    // Start observing the document body for added nodes
+    observer.observe(document.body, { childList: true, subtree: true });
+})();

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ UOW-TM-Tools is a collection of Tampermonkey scripts designed to enhance the use
 ## Features
 
 * **Moodle Popups** - Enhances Moodle by modifying popup behaviors for a more seamless navigation experience.
+* **Moodle Overdue Notification Remover** - Removes scary and erroneous overdue messages on Moodle.
 * **SOLS Auto Read** - Automates the process of marking SOLS messages as read, saving time and effort.
 * **SOLS WAM Calculator** - Automatically calculate your WAM score and add it to SOLS
 


### PR DESCRIPTION
This PR implements a Tampermonkey script that hides erroneous "overdue" badges displayed on the UOW Moodle. The script targets elements with the badge-danger class that contain the text "overdue" and removes them from the user interface without affecting other platform functionality.

Example of erroneous message
![image](https://github.com/user-attachments/assets/58af482b-b3d6-4c6c-aadd-a982418365c7)

